### PR TITLE
Update Pytorch example

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,11 @@ For a broader overview, check out [our paper](https://arxiv.org/abs/2008.05122) 
 
 ## Download and Installation
 
+LIT can be installed via pip, or can be built from source. Building from source
+is necessary if you wish to update any of the front-end or core back-end code.
+
+### Install from source
+
 Download the repo and set up a Python environment:
 
 ```sh
@@ -63,6 +68,18 @@ Note: if you see [an error](https://github.com/yarnpkg/yarn/issues/2821)
 running yarn on Ubuntu/Debian, be sure you have the
 [correct version installed](https://yarnpkg.com/en/docs/install#linux-tab).
 
+### pip installation
+
+```sh
+pip install lit-nlp
+```
+
+The pip installation will install all necessary prerequisite packages for use
+of the core LIT package. It also installs the code to run our demo examples.
+It does not install the prerequisites for those demos, so you need to install
+those yourself if you wish to run the demos. See
+[environment.yml](./environment.yml) for the list of all packages needed for
+running the demos.
 
 ## Running LIT
 

--- a/lit_nlp/__init__.py
+++ b/lit_nlp/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/lit_nlp/api/__init__.py
+++ b/lit_nlp/api/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/lit_nlp/app.py
+++ b/lit_nlp/app.py
@@ -17,6 +17,7 @@
 
 import collections
 import functools
+import glob
 import os
 import pickle
 import random
@@ -42,7 +43,6 @@ from lit_nlp.lib import caching
 from lit_nlp.lib import serialize
 from lit_nlp.lib import utils
 from lit_nlp.lib import wsgi_app
-import glob
 
 
 JsonDict = types.JsonDict

--- a/lit_nlp/components/__init__.py
+++ b/lit_nlp/components/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/lit_nlp/components/citrus/__init__.py
+++ b/lit_nlp/components/citrus/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/lit_nlp/components/index.py
+++ b/lit_nlp/components/index.py
@@ -30,7 +30,6 @@ from lit_nlp.lib import caching
 from lit_nlp.lib import utils
 
 
-
 class Indexer(object):
   """Class to build and search annoy indices.
 

--- a/lit_nlp/examples/__init__.py
+++ b/lit_nlp/examples/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/lit_nlp/examples/datasets/__init__.py
+++ b/lit_nlp/examples/datasets/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/lit_nlp/examples/datasets/classification.py
+++ b/lit_nlp/examples/datasets/classification.py
@@ -9,8 +9,6 @@ import pandas as pd
 import tensorflow_datasets as tfds
 
 
-
-
 def load_tfds(*args, **kw):
   """Load from TFDS."""
   # Materialize to NumPy arrays.

--- a/lit_nlp/examples/datasets/lm.py
+++ b/lit_nlp/examples/datasets/lm.py
@@ -1,12 +1,11 @@
 # Lint as: python3
 """Language modeling datasets."""
 
+import glob
 from lit_nlp.api import dataset as lit_dataset
 from lit_nlp.api import types as lit_types
 
 import tensorflow_datasets as tfds
-
-import glob
 
 
 class PlaintextSents(lit_dataset.Dataset):

--- a/lit_nlp/examples/models/__init__.py
+++ b/lit_nlp/examples/models/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/lit_nlp/examples/models/glue_models.py
+++ b/lit_nlp/examples/models/glue_models.py
@@ -1,5 +1,6 @@
 # Lint as: python3
 """Wrapper for fine-tuned HuggingFace models in LIT."""
+
 import os
 import re
 from typing import Optional, Dict, List, Iterable
@@ -12,8 +13,6 @@ from lit_nlp.lib import utils
 import numpy as np
 import tensorflow as tf
 import transformers
-
-
 
 JsonDict = lit_types.JsonDict
 Spec = lit_types.Spec

--- a/lit_nlp/examples/models/glue_models.py
+++ b/lit_nlp/examples/models/glue_models.py
@@ -1,5 +1,6 @@
 # Lint as: python3
 """Wrapper for fine-tuned HuggingFace models in LIT."""
+import os
 import re
 from typing import Optional, Dict, List, Iterable
 

--- a/lit_nlp/examples/simple_pytorch_demo.py
+++ b/lit_nlp/examples/simple_pytorch_demo.py
@@ -145,10 +145,10 @@ class SimpleSentimentModel(lit_model.Model):
     for output in utils.unbatch_preds(detached_outputs):
       ntok = output.pop("ntok")
       output["tokens"] = self.tokenizer.convert_ids_to_tokens(
-          output.pop("input_ids")[1:ntok - 1])
+          output.pop("input_ids")[:ntok])
 
       if self.compute_grads:
-        output["token_grad_sentence"] = output["input_emb_grad"][1:ntok - 1]
+        output["token_grad_sentence"] = output["input_emb_grad"][:ntok]
       if self.use_attentions:
         # Process attention.
         for key in output:

--- a/lit_nlp/examples/simple_pytorch_demo.py
+++ b/lit_nlp/examples/simple_pytorch_demo.py
@@ -44,6 +44,7 @@ from lit_nlp.lib import utils
 
 import torch
 import transformers
+import re
 
 # NOTE: additional flags defined in server_flags.py
 
@@ -70,6 +71,8 @@ class SimpleSentimentModel(lit_model.Model):
   """Simple sentiment analysis model."""
 
   LABELS = ["0", "1"]  # negative, positive
+  compute_grads: bool = False # if True, compute and return gradients.
+  use_attentions: bool = False # if True, return attentions.
 
   def __init__(self, model_name_or_path):
     self.tokenizer = transformers.AutoTokenizer.from_pretrained(
@@ -96,6 +99,7 @@ class SimpleSentimentModel(lit_model.Model):
     return 32
 
   def predict_minibatch(self, inputs):
+
     # Preprocess to ids and masks, and make the input batch.
     encoded_input = self.tokenizer.batch_encode_plus(
         [ex["sentence"] for ex in inputs],
@@ -104,24 +108,59 @@ class SimpleSentimentModel(lit_model.Model):
         max_length=128,
         pad_to_max_length=True)
 
+    if torch.cuda.is_available():
+      self.model.cuda()
+      for tensor in encoded_input:
+        encoded_input[tensor] = encoded_input[tensor].cuda()
+
     # Run a forward pass.
-    with torch.no_grad():  # remove this if you need gradients.
+    with torch.set_grad_enabled(self.compute_grads): # Conditional to use gradients
       logits, embs, unused_attentions = self.model(**encoded_input)
 
-    # Post-process outputs.
     batched_outputs = {
         "probas": torch.nn.functional.softmax(logits, dim=-1),
         "input_ids": encoded_input["input_ids"],
         "ntok": torch.sum(encoded_input["attention_mask"], dim=1),
         "cls_emb": embs[-1][:, 0],  # last layer, first token
     }
+
+    if self.use_attentions:
+      assert len(unused_attentions) == self.model.config.num_hidden_layers
+      for i, layer_attention in enumerate(unused_attentions):
+        batched_outputs[f"layer_{i}/attention"] = layer_attention
+
+    # Request gradients after the forward pass.
+    # Note: embs[0] includes position and segment encodings, as well as subword
+    # embeddings.
+    if self.compute_grads:
+      # <torch.float32>[batch_size, num_tokens, emb_dim]
+      scalar_pred_for_gradients = torch.max(batched_outputs["probas"], dim=1, keepdim=False, out=None)[0]
+      batched_outputs["input_emb_grad"] = torch.autograd.grad(scalar_pred_for_gradients, embs[0], grad_outputs = torch.ones_like(scalar_pred_for_gradients))[0]
+   
+    # Post-process outputs.
     # Return as NumPy for further processing.
-    detached_outputs = {k: v.numpy() for k, v in batched_outputs.items()}
+    detached_outputs = {k: v.cpu().detach().numpy() for k, v in batched_outputs.items()}
+    
     # Unbatch outputs so we get one record per input example.
     for output in utils.unbatch_preds(detached_outputs):
       ntok = output.pop("ntok")
       output["tokens"] = self.tokenizer.convert_ids_to_tokens(
           output.pop("input_ids")[1:ntok - 1])
+
+      if self.compute_grads:
+        output["token_grad_sentence"] = output["input_emb_grad"][1:ntok - 1]
+      if self.use_attentions:
+        # Process attention.
+        for key in output:
+          if not re.match(r"layer_(\d+)/attention", key):
+            continue
+          # Select only real tokens, since most of this matrix is padding.
+          # <float32>[num_heads, max_seq_length, max_seq_length]
+          # -> <float32>[num_heads, num_tokens, num_tokens]
+          output[key] = output[key][:, :ntok, :ntok].transpose((0, 2, 1))
+          # Make a copy of this array to avoid memory leaks, since NumPy otherwise
+          # keeps a pointer around that prevents the source array from being GCed.
+          output[key] = output[key].copy()
       yield output
 
   def input_spec(self) -> lit_types.Spec:
@@ -131,11 +170,22 @@ class SimpleSentimentModel(lit_model.Model):
     }
 
   def output_spec(self) -> lit_types.Spec:
-    return {
+    ret = {
         "tokens": lit_types.Tokens(),
         "probas": lit_types.MulticlassPreds(parent="label", vocab=self.LABELS),
         "cls_emb": lit_types.Embeddings()
     }
+    # Gradients, if requested.
+    if self.compute_grads:
+      ret["token_grad_sentence"] = lit_types.TokenGradients(
+          align="tokens")
+
+    if self.use_attentions:
+      # Attention heads, one field for each layer.
+      for i in range(self.model.config.num_hidden_layers):
+        ret[f"layer_{i}/attention"] = lit_types.AttentionHeads(
+            align=("tokens", "tokens"))
+    return ret
 
 
 def main(_):

--- a/lit_nlp/examples/tools/__init__.py
+++ b/lit_nlp/examples/tools/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/lit_nlp/examples/tools/glue_trainer.py
+++ b/lit_nlp/examples/tools/glue_trainer.py
@@ -28,8 +28,6 @@ from lit_nlp.examples.models import glue_models
 from lit_nlp.lib import serialize
 import tensorflow as tf
 
-
-
 flags.DEFINE_string("encoder_name", "bert-base-uncased",
                     "Model name or path to pretrained (base) encoder.")
 flags.DEFINE_string("task", "sst2", "Name of task to fine-tune on.")
@@ -70,7 +68,7 @@ def train_and_save(model, train_data, val_data, train_path):
   # Save model weights and config files.
   model.save(train_path)
   logging.info("Saved model files: \n  %s",
-               "\n  ".join(gfile.ListDir(train_path)))
+               "\n  ".join(os.listdir(train_path)))
 
 
 def main(_):

--- a/lit_nlp/lib/__init__.py
+++ b/lit_nlp/lib/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/lit_nlp/lib/caching.py
+++ b/lit_nlp/lib/caching.py
@@ -28,7 +28,6 @@ from lit_nlp.api import model as lit_model
 from lit_nlp.api import types
 from lit_nlp.lib import serialize
 
-
 JsonDict = types.JsonDict
 
 # Compound keys: (dataset_name, example_id)

--- a/lit_nlp/lib/testing_utils.py
+++ b/lit_nlp/lib/testing_utils.py
@@ -136,3 +136,11 @@ def fake_projection_input(n, num_dims):
   """Generates random embeddings in the correct format."""
   rng = np.random.RandomState(42)
   return [{'x': rng.rand(num_dims)} for i in range(n)]
+
+
+def assert_dicts_almost_equal(testcase, result, actual, places=3):
+  """Checks if provided dicts are almost equal."""
+  if set(result.keys()) != set(actual.keys()):
+    testcase.fail('results and actual have different keys')
+  for key in result:
+    testcase.assertAlmostEqual(result[key], actual[key], places=places)

--- a/lit_nlp/server_flags.py
+++ b/lit_nlp/server_flags.py
@@ -25,6 +25,10 @@ Usage:
 TODO(lit-dev): consider defining a single ConfigDict instead of individual
 flags.
 """
+
+import os
+import pathlib
+
 from absl import flags
 
 FLAGS = flags.FLAGS
@@ -59,8 +63,10 @@ flags.DEFINE_string(
     'default_layout', 'default',
     'Which layout to use by default (can be changed via url); see layout.ts')
 
-flags.DEFINE_string('client_root', './lit_nlp/client/build/',
-                    'Path to frontend client.')
+flags.DEFINE_string(
+    'client_root',
+    os.path.join(pathlib.Path(__file__).parent.absolute(), 'client', 'build'),
+   'Path to frontend client.')
 
 
 def get_flags():

--- a/pip_package/README.md
+++ b/pip_package/README.md
@@ -1,0 +1,30 @@
+# Language Interpretability Tool (LIT)
+
+The Language Interpretability Tool (LIT) is a visual, interactive
+model-understanding tool for NLP models.
+
+LIT is built to answer questions such as:
+
+*   **What kind of examples** does my model perform poorly on?
+*   **Why did my model make this prediction?** Can this prediction be attributed
+    to adversarial behavior, or to undesirable priors in the training set?
+*   **Does my model behave consistently** if I change things like textual style,
+    verb tense, or pronoun gender?
+
+LIT supports a variety of debugging workflows through a browser-based UI.
+Features include:
+
+*   **Local explanations** via salience maps, attention, and rich visualization
+    of model predictions.
+*   **Aggregate analysis** including custom metrics, slicing and binning, and
+    visualization of embedding spaces.
+*   **Counterfactual generation** via manual edits or generator plug-ins to
+    dynamically create and evaluate new examples.
+*   **Side-by-side mode** to compare two or more models, or one model on a pair
+    of examples.
+*   **Highly extensible** to new model types, including classification,
+    regression, span labeling, seq2seq, and language modeling. Supports
+    multi-head models and multiple input features out of the box.
+*   **Framework-agnostic** and compatible with TensorFlow, PyTorch, and more.
+
+The source code and documentation can be found at https://github.com/pair-code/lit.

--- a/pip_package/build_pip_package.sh
+++ b/pip_package/build_pip_package.sh
@@ -1,0 +1,59 @@
+#!/bin/sh
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# To use: Run './build_pip_package.sh' from this directory.
+# Package output location will be printed to the console upon completion.
+# Requires virtualenv and yarn to be installed.
+
+set -ex
+shopt -s extglob
+
+command -v virtualenv >/dev/null
+command -v yarn >/dev/null
+
+dest="/tmp/lit-pip"
+mkdir -p "$dest"
+
+source_dir="$PWD/.."
+
+pushd ../lit_nlp/client
+yarn && yarn build
+popd
+
+cd "$dest"
+
+mkdir -p release
+pushd release
+
+rm -rf lit_nlp
+cp -LR "$source_dir/pip_package/setup.py" .
+cp -LR "$source_dir/pip_package/README.md" .
+cp -LR "$source_dir/lit_nlp" .
+pushd lit_nlp/client
+rm -rf !(build)
+popd
+
+virtualenv venv
+export VIRTUAL_ENV=venv
+export PATH="$PWD/venv/bin:${PATH}"
+unset PYTHON_HOME
+
+# # Require wheel for bdist_wheel command, and setuptools 36.2.0+ so that
+# # env markers are handled (https://github.com/pypa/setuptools/pull/1081)
+pip install -qU wheel 'setuptools>=36.2.0'
+
+python setup.py bdist_wheel --python-tag py3 >/dev/null
+
+ls -hal "$PWD/dist"

--- a/pip_package/setup.py
+++ b/pip_package/setup.py
@@ -1,0 +1,51 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""lit-nlp pip package configuration."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import setuptools
+
+
+REQUIRED_PACKAGES = [
+    "absl-py",
+    "attrs",
+    "numpy",
+    "scipy",
+    "pandas",
+    "scikit-learn",
+    "lime",
+    "sacrebleu",
+    "umap-learn",
+    "Werkzeug",
+]
+
+with open("README.md", "r") as fh:
+  long_description = fh.read()
+
+setuptools.setup(
+    name="lit-nlp",
+    version="0.1.1",
+    description="Language Interpretability Tool.",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    url="https://github.com/pair-code/lit",
+    author="Google Inc.",
+    packages=setuptools.find_packages(),
+    license="Apache 2.0",
+    install_requires=REQUIRED_PACKAGES,
+    package_data={"lit_nlp": ["client/build/*", "client/build/static/*"]},
+)


### PR DESCRIPTION
The current pytorch example does not include gradient maps, attentions or GPU (cuda) access.

While Attention may not be relevant since there is no much difference on how add it with the TF examples, the gradient is computed differently for pytorch, hence it may be beneficial to include an example that uses it in pytorch.

The use of GPU if available seems to be working for TF examples, but not for pytorch.

Maybe this could be added as a different example since it may not be a mirror match of the simple TF example now, but the edits are not too substantial, and the use of attentions and gradients are conditional (set False by default).