### PR TITLE
Fix zindex bug on toolbar windows

### DIFF
--- a/lit_nlp/client/modules/app_toolbar.css
+++ b/lit_nlp/client/modules/app_toolbar.css
@@ -1,7 +1,7 @@
 #at-top {
   top: 0;
   position: sticky;
-  z-index: 1;
+  z-index: 3;
 }
 
 #toolbar {


### PR DESCRIPTION
hello!  In looking around, I expanded the embedding project and tried to color the data points, but the little window from the toolbar was occluded so I couldn't change the color.  This impacts the window that pops up for slices too, and presumably any others.

`z-index` interactions are always tricky :) but here's a fix, with the assumption that the toolbar windows should always be above any other maximized window.

### Screenshots
Look at the windows for toolbar actions.

#### before
<img width="1046" alt="Screen Shot 2020-09-14 at 10 05 45 AM" src="https://user-images.githubusercontent.com/1056957/93096710-b7e27e00-f672-11ea-9a29-fc57f84c271f.png">
<img width="1043" alt="Screen Shot 2020-09-14 at 10 15 46 AM" src="https://user-images.githubusercontent.com/1056957/93097208-45be6900-f673-11ea-9b1f-b0271fd97014.png">


#### after
<img width="1044" alt="Screen Shot 2020-09-14 at 10 07 41 AM" src="https://user-images.githubusercontent.com/1056957/93096884-ed876700-f672-11ea-99a5-a025e7fd1675.png">
<img width="1042" alt="Screen Shot 2020-09-14 at 10 14 04 AM" src="https://user-images.githubusercontent.com/1056957/93097066-17d92480-f673-11ea-822d-f57fa5029394.png">
