### PR TITLE
Limit caption on button adding all generated datapoints, show datapoint count above

### DIFF
--- a/lit_nlp/client/modules/generator_module.css
+++ b/lit_nlp/client/modules/generator_module.css
@@ -68,6 +68,10 @@
   min-width: 65px;
 }
 
+.counterfactuals-count {
+  padding-bottom: 5px;
+}
+
 #header{
   height: 35px;
   display: flex;

--- a/lit_nlp/client/modules/generator_module.ts
+++ b/lit_nlp/client/modules/generator_module.ts
@@ -184,6 +184,9 @@ export class GeneratorModule extends LitModule {
     // clang-format off
     return html`
         <div id='generated-holder'>
+          ${this.appliedGenerator === null || isGenerating || nothingGenerated ?
+            null :
+            html`<div class="counterfactuals-count">Generated ${this.totalNumGenerated} ${this.totalNumGenerated === 1 ? 'counterfactual' : 'counterfactuals'}.</div>`}
           ${this.renderHeader()}
           <div class="entries">
             ${isGenerating ? html`<div>Generating...</div>` : null}
@@ -247,7 +250,7 @@ export class GeneratorModule extends LitModule {
         ${this.renderKeys()}
         ${this.totalNumGenerated <= 0 ? null : html`
           <button class='button add-button' @click=${onAddAll}>
-             Add (${this.totalNumGenerated})
+             Add all
           </button>
           <button class='button' @click=${this.resetEditedData}>
              Clear


### PR DESCRIPTION
In the counterfactual datapoint generator, the button that allows users to add all datapoints also shows how many datapoints there are.  But the text overflows the button size, which I think comes from the JS code sizing this as a table.  The test case here is the quickstart SST, selecting all data points, and generating counterfactuals for the default  "great -> terrible" in a 1440px wide window.

One small fix could be to change the caption to "+12" which fits for n<10k.  This pull request changes the button to "Add all," which will always fit, and adds a line above the table for showing how many rows were generated.  The downside is taking up that row of space.

### before
<img width="1440" alt="Screen Shot 2020-09-15 at 10 31 52 AM" src="https://user-images.githubusercontent.com/1056957/93225941-c6976680-f740-11ea-97f4-24f5b55c6093.png">

### this pull request
<img width="1440" alt="Screen Shot 2020-09-15 at 10 51 57 AM" src="https://user-images.githubusercontent.com/1056957/93226623-84baf000-f741-11ea-8522-6193470d4e9d.png">

### alternately
<img width="1440" alt="three" src="https://user-images.githubusercontent.com/1056957/93227312-3a863e80-f742-11ea-8da2-22df398dc631.png">
