### PR TITLE
Fix whitescreen bug when configuring which modules are visible

### DIFF
--- a/lit_nlp/client/core/modules.ts
+++ b/lit_nlp/client/core/modules.ts
@@ -181,9 +181,7 @@ export class LitModules extends LitElement {
 
   renderComponentType(configGroup: RenderConfig[]) {
     const modulesInGroup = configGroup.length > 1;
-    const duplicateAsRow = (configGroup.length > 0)
-      ? configGroup[0].moduleType.duplicateAsRow
-      : false;
+    const duplicateAsRow = configGroup[0].moduleType.duplicateAsRow;
     const componentsHTML = configGroup.map(
         config => this.renderModule(config, modulesInGroup && !duplicateAsRow));
     if (modulesInGroup) {

--- a/lit_nlp/client/core/modules.ts
+++ b/lit_nlp/client/core/modules.ts
@@ -181,7 +181,9 @@ export class LitModules extends LitElement {
 
   renderComponentType(configGroup: RenderConfig[]) {
     const modulesInGroup = configGroup.length > 1;
-    const duplicateAsRow = configGroup[0].moduleType.duplicateAsRow;
+    const duplicateAsRow = (configGroup.length > 0)
+      ? configGroup[0].moduleType.duplicateAsRow
+      : false;
     const componentsHTML = configGroup.map(
         config => this.renderModule(config, modulesInGroup && !duplicateAsRow));
     if (modulesInGroup) {

--- a/lit_nlp/client/services/modules_service.ts
+++ b/lit_nlp/client/services/modules_service.ts
@@ -141,9 +141,9 @@ export class ModulesService extends LitService implements
   }
 
   private filterHiddenConfigs(configs: RenderConfig[][]): RenderConfig[][] {
-    return configs.map(configGroup => {
-      return configGroup.filter(config => !this.isConfigHidden(config));
-    }).filter(configGroup => configGroup.length > 0);
+    return configs.filter(configGroup => {
+      return (configGroup.length === 0) || !this.isConfigHidden(configGroup[0]);
+    });
   }
 
   private isConfigHidden(config: RenderConfig) {

--- a/lit_nlp/client/services/modules_service.ts
+++ b/lit_nlp/client/services/modules_service.ts
@@ -143,7 +143,7 @@ export class ModulesService extends LitService implements
   private filterHiddenConfigs(configs: RenderConfig[][]): RenderConfig[][] {
     return configs.map(configGroup => {
       return configGroup.filter(config => !this.isConfigHidden(config));
-    });
+    }).filter(configGroup => configGroup.length > 0);
   }
 
   private isConfigHidden(config: RenderConfig) {


### PR DESCRIPTION
hello!  I'm not sure any users actually want to do this :) but I ran into it and figured I'd try to contribute something useful as I'm looking around 👍 

If a user disables the embedding projector...
<img width="792" alt="Screen Shot 2020-09-16 at 1 27 10 PM" src="https://user-images.githubusercontent.com/1056957/93371413-5829d580-f820-11ea-8dff-6cea1695d341.png">

There's a JS error and they get a whitescreen...
<img width="1440" alt="Screen Shot 2020-09-16 at 1 25 43 PM" src="https://user-images.githubusercontent.com/1056957/93371398-4b0ce680-f820-11ea-9d1c-ba2418c6fb46.png">

Here's the stack trace:
<img width="964" alt="Screen Shot 2020-09-16 at 1 20 10 PM" src="https://user-images.githubusercontent.com/1056957/93371473-6d9eff80-f820-11ea-985d-7e38c84be647.png">

The immediate issue is that the module loader assumes that it can peek inside the `LitRenderConfig` to figure out whether it should `duplicateAsRow`.  But if I'm following, this is an upstream bug in how the Modules services filters the config based on what should be hidden, within `filterHiddenConfigs`.

This is after the fix:
<img width="1440" alt="Screen Shot 2020-09-16 at 1 25 16 PM" src="https://user-images.githubusercontent.com/1056957/93372609-1b5ede00-f822-11ea-93c6-4da5ca1e070b.png">
