### PR TITLE
Embeddings: Update colors when classification threshold is changed

### DIFF
--- a/lit_nlp/client/modules/embeddings_module.ts
+++ b/lit_nlp/client/modules/embeddings_module.ts
@@ -193,8 +193,8 @@ export class EmbeddingsModule extends LitModule {
    */
   private setupReactions() {
     // Don't react immediately; we'll wait and make a single update.
-    const getSelectedColorOption = () => this.colorService.selectedColorOption;
-    this.react(getSelectedColorOption, selectedColorOption => {
+    const getColorAll = () => this.colorService.all;
+    this.react(getColorAll, selectedColorOption => {
       // pointColorer uses the latest settings from colorService automatically,
       // so to pick up the colors we just need to trigger a rerender on
       // scatterGL.

--- a/lit_nlp/client/services/color_service.ts
+++ b/lit_nlp/client/services/color_service.ts
@@ -55,6 +55,14 @@ export class ColorService extends LitService {
   @observable selectedColorOption = this.defaultOption;
 
   @computed
+  get all() {
+    return [
+      this.selectedColorOption,
+      this.classificationService.allMarginSettings
+    ];
+  }
+
+  @computed
   get colorableOptions() {
     const catInputFeatureOptions =
         this.groupService.categoricalFeatureNames.map((feature: string) => {


### PR DESCRIPTION
hello!  I noticed that when a user adjusts the classification threshold slider in the Prediction Score module, the coloring of data points in that window will react in that window but not in the Embeddings module.  This pull request adds a listener for that.

I looked at why this isn't just updating, but didn't find a smoking gun.  I suspect there's a some use of a property somewhere that isn't being tracked but couldn't find it.  Adding in more dependencies (eg, add in `colorableOptions` to `colorService.all`) resulted in a whole lot of unnecessary work so I didn't spend any time thinking through more involved changes.

This pull request just adds `colorService.all` and updates the Embeddings module to listen for it, rather than adding a new listener on the classification service directly.

### before
The Embeddings module doesn't pick up the color changes from adjusting the threshold slider.
<img width="1165" alt="Screen Shot 2020-09-17 at 4 39 45 PM" src="https://user-images.githubusercontent.com/1056957/93525680-69e4a900-f904-11ea-8c15-4da4a094beee.png">

### after
<img width="1158" alt="Screen Shot 2020-09-17 at 4 23 38 PM" src="https://user-images.githubusercontent.com/1056957/93525840-95679380-f904-11ea-9940-ffe99545497b.png">
<img width="1167" alt="Screen Shot 2020-09-17 at 4 23 45 PM" src="https://user-images.githubusercontent.com/1056957/93525842-96002a00-f904-11ea-8545-6a497b1a1278.png">

Same for the other coloring options as well.
<img width="1163" alt="Screen Shot 2020-09-17 at 4 23 59 PM" src="https://user-images.githubusercontent.com/1056957/93525862-9dbfce80-f904-11ea-9ba2-436be665a7b8.png">
