### PR TITLE
Perturbations Table Module

### DIFF
--- a/lit_nlp/client/core/lit_app.ts
+++ b/lit_nlp/client/core/lit_app.ts
@@ -34,6 +34,7 @@ import {SliceService} from '../services/slice_service';
 import {AppState} from '../services/state_service';
 import {StatusService} from '../services/status_service';
 import {UrlService} from '../services/url_service';
+import {DeltasService} from '../services/deltas_service';
 
 
 /**
@@ -141,6 +142,8 @@ export class LITApp {
     const groupService = new GroupService(appState);
     const colorService = new ColorService(
         appState, groupService, classificationService, regressionService);
+    const deltasService = new DeltasService(
+        appState, selectionService, classificationService, regressionService);
 
     selectionService.setAppState(appState);
 
@@ -160,6 +163,7 @@ export class LITApp {
     this.services.set(SliceService, sliceService);
     this.services.set(StatusService, statusService);
     this.services.set(UrlService, urlService);
+    this.services.set(DeltasService, deltasService);
   }
 }
 

--- a/lit_nlp/client/elements/text_diff.css
+++ b/lit_nlp/client/elements/text_diff.css
@@ -1,0 +1,8 @@
+.output {
+  display: flex;
+}
+
+.highlighted {
+  color: #ffa500;
+  font-weight: bold;
+}

--- a/lit_nlp/client/elements/text_diff.ts
+++ b/lit_nlp/client/elements/text_diff.ts
@@ -1,0 +1,165 @@
+/**
+ * @license
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import difflib from 'difflib';
+
+import {css, customElement, html, LitElement, property} from 'lit-element';
+import {classMap} from 'lit-html/directives/class-map';
+import {styleMap} from 'lit-html/directives/style-map';
+
+import {styles} from './text_diff.css';
+
+interface TextDiff {
+  inputStrings: string[];
+  outputStrings: string[];
+  equal: boolean[];
+}
+
+
+/**
+ * A component that renders the diff between two strings, with the differences
+ * highlighted.  It can show before before and after, or only after.
+ */
+@customElement('lit-text-diff')
+export class TextDiffComponent extends LitElement {
+  /* The two text values to diff */
+  @property({type: String}) beforeText = undefined;
+  @property({type: String}) afterText = undefined;
+
+  /* Show a label next to the before/after text itself */
+  @property({type: String}) beforeLabel = undefined;
+  @property({type: String}) afterLabel = undefined;
+
+  /* Allow only rendering before or after, instead of both */
+  @property({type: Boolean}) includeBefore = true;
+  @property({type: Boolean}) includeAfter = true;
+
+  /* Optional: Diff by character instead of by word */
+  @property({type: Boolean}) byCharacter = false;
+
+  static get styles() {
+    return styles;
+  }
+
+  render() {
+    // textDiff contains arrays of parsed segments from both strings, and an
+    // array of booleans indicating whether the corresponding change type is
+    // 'equal.'
+    const textDiff = getTextDiff(this.beforeText!, this.afterText!, !this.byCharacter);
+
+
+    // Highlight strings as bold if they don't match (and the changetype is
+    // not 'equal').
+    // clang-format off
+    return html`
+      ${this.includeBefore
+        ? this.renderDiffString(textDiff.inputStrings, textDiff.equal, this.beforeLabel)
+        : null}
+      ${this.includeAfter
+        ? this.renderDiffString(textDiff.outputStrings, textDiff.equal, this.afterLabel)
+        : null}
+      <br>
+    `;
+    // clang-format on
+  }
+
+  renderDiffString(strings: string[], equal: boolean[], label?: string) {
+    const byWord = !this.byCharacter;
+    let displayStrings = strings;
+
+    // Add spaces between strings for the word-wise character diffs.
+    if (byWord) {
+      const lastIndex = strings.length - 1;
+      displayStrings = strings.map((item, i) => {
+        if (i !== lastIndex) {
+          return item.concat(' ');
+        }
+        return item;
+      });
+    }
+
+    // clang-format off
+    return html`
+      <div class="output">
+        ${label && html`<div class="key">${label} </div>`}
+        <div class="value">
+          ${displayStrings.map((output, i) => {
+            const classes = classMap({
+              highlighted: !equal[i],
+            });
+            return html`<span class=${classes}>${output}</span>`;
+          })}
+        </div>
+      </div>
+    `;
+    // clang-format on
+  }
+}
+
+
+/**
+ * Uses difflib library to compute character differences between the input
+ * strings and returns a TextDiff object, which contains arrays of parsed
+ * segments from both strings and an array of booleans indicating whether the
+ * corresponding change type is 'equal.'
+ */
+export function getTextDiff(
+    targetText: string, outputText: string, byWord: boolean): TextDiff {
+  // Use difflib library to compute opcodes, which contain a group of changes
+  // between the two input strings. Each opcode contains the change type and
+  // the start/end of the concerned characters/words in each string.
+  const targetWords = targetText.split(' ');
+  const outputWords = outputText.split(' ');
+
+  const matcher = byWord ?
+      new difflib.SequenceMatcher(() => false, targetWords, outputWords) :
+      new difflib.SequenceMatcher(() => false, targetText, outputText);
+  const opcodes = matcher.getOpcodes();
+
+  // Store an array of the parsed segments from both strings and whether
+  // the change type is 'equal.'
+  const inputStrings: string[] = [];
+  const outputStrings: string[] = [];
+  const equal: boolean[] = [];
+
+  for (const opcode of opcodes) {
+    const changeType = opcode[0];
+    const startA = Number(opcode[1]);
+    const endA = Number(opcode[2]);
+    const startB = Number(opcode[3]);
+    const endB = Number(opcode[4]);
+
+    equal.push((changeType === 'equal'));
+
+    if (byWord) {
+      inputStrings.push(targetWords.slice(startA, endA).join(' '));
+      outputStrings.push(outputWords.slice(startB, endB).join(' '));
+    } else {
+      inputStrings.push(targetText.slice(startA, endA));
+      outputStrings.push(outputText.slice(startB, endB));
+    }
+  }
+
+  const textDiff: TextDiff = {inputStrings, outputStrings, equal};
+  return textDiff;
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'lit-text-diff': TextDiffComponent;
+  }
+}

--- a/lit_nlp/client/elements/text_diff_test.ts
+++ b/lit_nlp/client/elements/text_diff_test.ts
@@ -16,7 +16,7 @@
  */
 
 import 'jasmine';
-import {getTextDiff} from './generated_text_module';
+import {getTextDiff} from './text_diff';
 
 describe('getTextDiff test', () => {
   /** Character diff tests */

--- a/lit_nlp/client/layout.ts
+++ b/lit_nlp/client/layout.ts
@@ -28,6 +28,7 @@ import {GeneratedTextModule} from './modules/generated_text_module';
 import {GeneratorModule} from './modules/generator_module';
 import {LanguageModelPredictionModule} from './modules/lm_prediction_module';
 import {MetricsModule} from './modules/metrics_module';
+import {PerturbationsTableModule} from './modules/perturbations_table_module';
 import {PredictionScoreModule} from './modules/prediction_score_module';
 import {RegressionModule} from './modules/regression_module';
 import {SalienceMapModule} from './modules/salience_map_module';
@@ -129,6 +130,7 @@ export const LAYOUTS: LitComponentLayouts = {
       'Predictions': [
         ...MODEL_PREDS_MODULES,
         PredictionScoreModule,
+
       ],
       'Explanations': [
         ...MODEL_PREDS_MODULES,
@@ -137,6 +139,9 @@ export const LAYOUTS: LitComponentLayouts = {
       ],
       'Counterfactuals': [GeneratorModule],
       'Counterfactual Explanation': [CounterfactualExplainerModule],
+      'Counterfactual Changes': [
+        PerturbationsTableModule
+      ]
     }
   },
 };

--- a/lit_nlp/client/lib/utils.ts
+++ b/lit_nlp/client/lib/utils.ts
@@ -228,3 +228,13 @@ export function roundToDecimalPlaces(num: number, places: number) {
   const numForPlaces = Math.pow(10, places);
   return Math.round((num + Number.EPSILON) * numForPlaces) / numForPlaces;
 }
+
+/**
+ * Format for showing the user; may be a regression score or classification index.
+ */
+export function formatLabelNumber(num: number) {
+  if (typeof num === 'number' && num % 1 !== 0) {
+    return num.toFixed(3);
+  }
+  return num;
+}

--- a/lit_nlp/client/modules/data_table_module.ts
+++ b/lit_nlp/client/modules/data_table_module.ts
@@ -79,13 +79,6 @@ export class DataTableModule extends LitModule {
     return ['index', 'id', ...this.keys];
   }
 
-  @computed
-  get selectedRowIndices(): number[] {
-    return this.selectionService.selectedIds
-        .map((id) => this.appState.getIndexById(id))
-        .filter((index) => index !== -1);
-  }
-
   /**
    * Keys of the format 'rowName:columnName' (formatted with getTableKey()) map
    * to the cell value at this row and column location.
@@ -370,7 +363,6 @@ export class DataTableModule extends LitModule {
     return `${row}:${column}`;
   }
 
-
   onSelect(selectedRowIndices: number[]) {
     const ids = selectedRowIndices
                     .map(index => this.appState.currentInputData[index]?.id)
@@ -408,7 +400,7 @@ export class DataTableModule extends LitModule {
         <lit-data-table
           .columnVisibility=${this.columnVisibility}
           .data=${this.data}
-          .selectedIndices=${this.selectedRowIndices}
+          .selectedIndices=${this.selectionService.selectedRowIndices}
           .primarySelectedIndex=${primarySelectedIndex}
           .referenceSelectedIndex=${referenceSelectedIndex}
           .onSelect=${onSelect}

--- a/lit_nlp/client/modules/datapoint_editor_module.ts
+++ b/lit_nlp/client/modules/datapoint_editor_module.ts
@@ -212,7 +212,7 @@ export class DatapointEditorModule extends LitModule {
       const toCreate = [[this.editedData]];
       const ids = [this.selectionService.primarySelectedId!];
       const datapoints =
-          await this.appState.createNewDatapoints(toCreate, ids, 'manual');
+          await this.appState.createNewDatapoints(toCreate, ids, 'manual', '(manual)');
       this.selectionService.selectIds(datapoints.map(d => d.id));
     };
     const onClickReset = () => {

--- a/lit_nlp/client/modules/generated_text_module.ts
+++ b/lit_nlp/client/modules/generated_text_module.ts
@@ -153,108 +153,19 @@ export class GeneratedTextModule extends LitModule {
   renderDiffText(
       targetField: string, targetText: string, outputKey: string,
       outputText: string) {
-    // textDiff contains arrays of parsed segments from both strings, and an
-    // array of booleans indicating whether the corresponding change type is
-    // 'equal.'
-    const byWord = this.isChecked;
-    const textDiff = getTextDiff(targetText, outputText, byWord);
-
-
-    // Highlight strings as bold if they don't match (and the changetype is
-    // not 'equal').
-    // clang-format off
     return html`
-      ${this.renderDiffString(
-            targetField, textDiff.inputStrings, textDiff.equal, byWord)}
-      ${this.renderDiffString(
-            outputKey, textDiff.outputStrings, textDiff.equal, byWord)}
-      <br>
+      <lit-text-diff
+        beforeLabel=${targetField}
+        beforeText=${targetText}        
+        afterLabel=${outputKey}
+        afterText=${outputText}
+      /></lit-text-diff>
     `;
-    // clang-format on
-  }
-
-  renderDiffString(
-      key: string, strings: string[], equal: boolean[], byWord: boolean) {
-    let displayStrings = strings;
-
-    // Add spaces between strings for the word-wise character diffs.
-    if (byWord) {
-      const lastIndex = strings.length - 1;
-      displayStrings = strings.map((item, i) => {
-        if (i !== lastIndex) {
-          return item.concat(' ');
-        }
-        return item;
-      });
-    }
-
-    // clang-format off
-    return html`
-      <div class="output">
-        <div class="key">${key} </div>
-        <div class="value">
-          ${displayStrings.map((output, i) => {
-            const classes = classMap({
-              highlighted: !equal[i],
-            });
-            return html`<span class=${classes}>${output}</span>`;
-          })}
-        </div>
-      </div>
-    `;
-    // clang-format on
   }
 
   static shouldDisplayModule(modelSpecs: ModelsMap, datasetSpec: Spec) {
     return doesOutputSpecContain(modelSpecs, 'GeneratedText');
   }
-}
-
-/**
- * Uses difflib library to compute character differences between the input
- * strings and returns a TextDiff object, which contains arrays of parsed
- * segments from both strings and an array of booleans indicating whether the
- * corresponding change type is 'equal.'
- */
-export function getTextDiff(
-    targetText: string, outputText: string, byWord: boolean): TextDiff {
-  // Use difflib library to compute opcodes, which contain a group of changes
-  // between the two input strings. Each opcode contains the change type and
-  // the start/end of the concerned characters/words in each string.
-  const targetWords = targetText.split(' ');
-  const outputWords = outputText.split(' ');
-
-  const matcher = byWord ?
-      new difflib.SequenceMatcher(() => false, targetWords, outputWords) :
-      new difflib.SequenceMatcher(() => false, targetText, outputText);
-  const opcodes = matcher.getOpcodes();
-
-  // Store an array of the parsed segments from both strings and whether
-  // the change type is 'equal.'
-  const inputStrings: string[] = [];
-  const outputStrings: string[] = [];
-  const equal: boolean[] = [];
-
-  for (const opcode of opcodes) {
-    const changeType = opcode[0];
-    const startA = Number(opcode[1]);
-    const endA = Number(opcode[2]);
-    const startB = Number(opcode[3]);
-    const endB = Number(opcode[4]);
-
-    equal.push((changeType === 'equal'));
-
-    if (byWord) {
-      inputStrings.push(targetWords.slice(startA, endA).join(' '));
-      outputStrings.push(outputWords.slice(startB, endB).join(' '));
-    } else {
-      inputStrings.push(targetText.slice(startA, endA));
-      outputStrings.push(outputText.slice(startB, endB));
-    }
-  }
-
-  const textDiff: TextDiff = {inputStrings, outputStrings, equal};
-  return textDiff;
 }
 
 declare global {

--- a/lit_nlp/client/modules/generator_module.ts
+++ b/lit_nlp/client/modules/generator_module.ts
@@ -145,8 +145,9 @@ export class GeneratorModule extends LitModule {
 
   private async createNewDatapoints(
       data: Input[][], parentIds: string[], source: string) {
+    const rule = (this.appliedGenerator === 'word_replacer') ? this.substitutions : undefined;
     const newExamples =
-        await this.appState.createNewDatapoints(data, parentIds, source);
+        await this.appState.createNewDatapoints(data, parentIds, source, rule);
     const newIds = newExamples.map(d => d.id);
     if (newIds.length === 0) return;
 

--- a/lit_nlp/client/modules/metrics_module.ts
+++ b/lit_nlp/client/modules/metrics_module.ts
@@ -24,7 +24,7 @@ import {app} from '../core/lit_app';
 import {LitModule} from '../core/lit_module';
 import {TableData} from '../elements/table';
 import {CallConfig, FacetMap, GroupedExamples, IndexedInput, LitName, ModelsMap, Spec} from '../lib/types';
-import {doesOutputSpecContain} from '../lib/utils';
+import {doesOutputSpecContain, formatLabelNumber} from '../lib/utils';
 import {GroupService} from '../services/group_service';
 import {ClassificationService, SliceService} from '../services/services';
 
@@ -132,11 +132,7 @@ export class MetricsModule extends LitModule {
       // Add the metrics columns.
       const rowMetrics = metricNames.map((key: string) => {
         const num = d.metrics[key] ?? '-';
-        // If the metric is not a whole number, then round to 3 decimal places.
-        if (typeof num === 'number' && num % 1 !== 0) {
-          return num.toFixed(3);
-        }
-        return num;
+        return formatLabelNumber(num);
       });
 
       // Add the "Facet by" columns.

--- a/lit_nlp/client/modules/perturbations_table_module.css
+++ b/lit_nlp/client/modules/perturbations_table_module.css
@@ -1,0 +1,36 @@
+.info {
+  padding: 5px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  color: #3c4043;
+}
+
+.table-container {
+  padding-bottom: 20px;
+}
+
+.navigation-strip {
+  display: flex;
+  align-items: center;
+}
+
+.navigation-buttons {
+  height: 16px;
+  padding-left: 5px;
+}
+
+.icon-button {
+  width: 16px;
+  height: 16px;
+  font-size: 16px;
+  font-weight: bold;
+  cursor: pointer;
+  user-select: none;
+}
+
+.icon-placeholder {
+  width: 16px;
+  height: 16px;
+  display: inline-block;
+}

--- a/lit_nlp/client/modules/perturbations_table_module.ts
+++ b/lit_nlp/client/modules/perturbations_table_module.ts
@@ -1,0 +1,286 @@
+/**
+ * @license
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// tslint:disable:no-new-decorators
+import '@material/mwc-icon';
+
+import * as d3 from 'd3';
+import {customElement, html} from 'lit-element';
+import {computed, observable} from 'mobx';
+import {classMap} from 'lit-html/directives/class-map';
+import {styleMap} from 'lit-html/directives/style-map';
+
+import '../elements/text_diff';
+import {app} from '../core/lit_app';
+import {LitModule} from '../core/lit_module';
+import {TableData} from '../elements/table';
+import {CallConfig, FacetMap, GroupedExamples, IndexedInput, LitName, ModelsMap, Spec} from '../lib/types';
+import {doesOutputSpecContain, formatLabelNumber, findSpecKeys} from '../lib/utils';
+import {GroupService} from '../services/group_service';
+import {DeltasService, RegressionService, ClassificationService, SliceService} from '../services/services';
+import {RegressionInfo} from '../services/regression_service';
+import {DeltaRow, DeltaInfo, Source} from '../services/deltas_service';
+
+import {styles} from './perturbations_table_module.css';
+import {styles as sharedStyles} from './shared_styles.css';
+
+
+/**
+ * Module to sort generated countefactuals by the change in prediction for a
+ regression or multiclass classification model.
+ */
+@customElement('perturbations-table-module')
+export class PerturbationsTableModule extends LitModule {
+  static title = 'Perturbations';
+  static numCols = 8;
+  static template = () => {
+    return html`<perturbations-table-module></perturbations-table-module>`;
+  };
+
+  static shouldDisplayModule(modelSpecs: ModelsMap, datasetSpec: Spec) {
+    return doesOutputSpecContain(modelSpecs, [
+      'RegressionScore',
+      'MulticlassPreds'
+    ]);
+  }
+
+  static get styles() {
+    return [sharedStyles, styles];
+  }
+
+  static duplicateForModelComparison = true;
+
+  private readonly regressionService = app.getService(RegressionService);
+  private readonly classificationService = app.getService(ClassificationService);
+  private readonly deltasService = app.getService(DeltasService);
+
+  /* These constants are for referring to table columns */
+  private readonly SENTENCE_COLUMN = 0;
+  private readonly DELTA_COLUMN = 4;
+  private readonly ID_COLUMN = 5;
+  private readonly NUMERIC_DELTA_COLUMN = 6;
+  private readonly PLAIN_TEXT_COLUMN = 7;
+  
+  private onSelect(selectedRowIndices: number[]) {
+    const ids = selectedRowIndices
+                    .map(index => this.appState.currentInputData[index]?.id)
+                    .filter(id => id != null);
+    this.selectionService.selectIds(ids);
+  }
+
+  private onPrimarySelect(index: number) {
+    const id = (index === -1)
+      ? null
+      : this.appState.currentInputData[index]?.id ?? null;
+    this.selectionService.setPrimarySelection(id);
+  }
+
+  render() {
+    const ds = this.appState.generatedDataPoints;
+    if (ds.length === 0) {
+      return html`<div class="info">No counterfactuals created yet.</div>`;
+    }
+
+    /* Consider classification and regression predictions, and fan out by
+     * each (model, outputKey, fieldName)
+     */
+    return this.deltasService.sources.map((source, index) => {
+      return this.renderHeaderAndTable(source, index);
+    });
+
+  }
+
+  private renderHeaderAndTable(source: Source, sourceIndex: number) {
+    const {fieldName} = source;
+
+    const {generationKeys, deltaRows} = this.deltasService.deltaInfoFromSource(source);
+    const tableRows = this.formattedTableRows(deltaRows);
+    return html`
+      <div>
+        ${this.renderHeader(generationKeys.length, tableRows.length, sourceIndex)}
+        ${this.renderTable(source, tableRows)}
+        }
+      </div>
+    `;
+  }
+
+  private renderHeader(generationsCount: number, rowsCount: number, sourceIndex: number) {
+    return html`
+      <div class="info">
+        <span>
+          Generated ${rowsCount === 1 ? '1 datapoint' : `${rowsCount} datapoints`}
+          from ${generationsCount === 1 ? '1 perturbation' : `${generationsCount} perturbations`}
+        </span>
+        ${this.renderNavigationStrip(sourceIndex)}
+       </div>
+    `;
+  }
+
+  private renderNavigationStrip(sourceIndex: number) {
+    const sources = this.deltasService.sources;
+    if (sources.length === 1) {
+      return null;
+    }
+
+    const onChangeOffset = (delta: number) => {
+      const infos = this.shadowRoot!.querySelectorAll('.info');
+      const nextIndex = sourceIndex + delta;
+      if (nextIndex < infos.length && nextIndex >= 0) {
+        infos[nextIndex].scrollIntoView();
+       }
+    };
+
+    const previousButton = html`
+      <mwc-icon class='icon-button'
+        @click=${() => {onChangeOffset(-1);}}>
+        chevron_left
+      </mwc-icon>
+    `;
+    const nextButton = html`
+      <mwc-icon class='icon-button'
+        @click=${() => {onChangeOffset(1);}}>
+        chevron_right
+      </mwc-icon>
+    `;
+    const placeholderButton = html`<div class="icon-placeholder"> </div>`;
+    return html`
+      <span class="navigation-strip">
+        ${sourceIndex + 1} of ${sources.length} fields
+        <span class="navigation-buttons">
+          ${sourceIndex - 1 >= 0 ? previousButton : placeholderButton}
+          ${sourceIndex + 1 < sources.length ? nextButton : placeholderButton}
+        </span>
+      </span>
+    `;
+  }
+
+  private formattedTableRows(deltaRows: DeltaRow[]): TableData[] {
+    const BLANK = '-';
+    const meanAbsDelta = d3.mean(deltaRows.filter(d => d.delta != null), d => {
+      return Math.abs(d.delta!);
+    });
+
+    // Some columns are listed twice in different formats, one that's formatted
+    // to be user-facing, and another with values that are hidden but sortable
+    // for the table component.
+    return deltaRows.map((deltaRow: DeltaRow) => {
+      const {before, after, delta, d, parent}  = deltaRow;
+      const row: TableData = [
+        this.renderSentenceWithDiff(parent.data.sentence, d.data.sentence), // SENTENCE_COLUMN
+        d.meta.rule ? d.meta.rule : d.meta.source,
+        before ? formatLabelNumber(before) : BLANK,
+        after ? formatLabelNumber(after) : BLANK,
+        delta ? this.renderDeltaCell(delta, meanAbsDelta) : BLANK, // DELTA_COLUMN
+        d.id, // ID_COLUMN
+        delta ? delta : 0, // NUMERIC_DELTA_COLUMN
+        d.data.sentence // PLAIN_TEXT_COLUMN
+      ];
+
+      return row;
+    });
+  }
+
+  private renderSentenceWithDiff(before: string, after: string) {
+    return html`
+      <lit-text-diff
+        beforeText=${before}
+        afterText=${after}
+        .includeBefore=${false}
+      /></lit-text-diff>
+    `;
+  }
+
+  private renderDeltaCell(delta: number, meanAbsDelta?: number) {
+    /// Styles, because classes won't apply within the table's shadow DOM
+    const opacity = meanAbsDelta ? Math.abs(delta) / meanAbsDelta : 0.5;
+    const styles = styleMap({
+      'font-size': '12px',
+      'opacity': opacity.toFixed(3),
+      'vertical-align': 'middle'
+    });
+    return html`
+      <div>
+        <mwc-icon class="HUGE" style=${styles}>
+          ${delta > 0 ? 'arrow_upward' : 'arrow_downward'}
+        </mwc-icon>
+        ${formatLabelNumber(Math.abs(delta))}
+      </div>
+    `;
+  }
+
+  private renderTable(source: Source, rows: TableData[]) {
+    const {fieldName} = source;
+
+    const columnVisibility = new Map<string, boolean>();
+    columnVisibility.set('generated sentence', true);
+    columnVisibility.set(`source`, true);
+    columnVisibility.set(`parent ${fieldName}`, true);
+    columnVisibility.set(`${fieldName}`, true);
+    columnVisibility.set('delta', true);
+    columnVisibility.set('id', false);
+    columnVisibility.set('numeric_delta', false);
+    columnVisibility.set('sentence plain text', false);
+    
+    const onSelect = (selectedRowIndices: number[]) => {
+      this.onSelect(selectedRowIndices);
+    };
+    const onPrimarySelect = (index: number) => {
+      this.onPrimarySelect(index);
+    };
+    
+    /* Adjust how sorting is done, for columns that include non-sortable
+     * values (eg, HTML TemplateResult, or some other formatting)
+     */
+    const getSortValue = (row: TableData, column: number) => {
+      if (column === this.SENTENCE_COLUMN) {
+        return row[this.PLAIN_TEXT_COLUMN];
+      } else if (column === this.DELTA_COLUMN) {
+        return row[this.NUMERIC_DELTA_COLUMN];
+      }
+      return row[column];
+    }
+    const getDataIndexFromRow = (row: TableData) => {
+      const id = row[this.ID_COLUMN];
+      return this.appState.getIndexById(id as string);
+    };
+    const primarySelectedIndex =
+      this.appState.getIndexById(this.selectionService.primarySelectedId);
+
+    return html`
+      <div class="table-container">
+        <lit-data-table
+          defaultSortName="delta"
+          .defaultSortAscending=${false}
+          .columnVisibility=${columnVisibility}
+          .data=${rows}
+          .selectedIndices=${this.selectionService.selectedRowIndices}
+          .primarySelectedIndex=${primarySelectedIndex}
+          .onSelect=${onSelect}
+          .onPrimarySelect=${onPrimarySelect}
+          .getDataIndexFromRow=${getDataIndexFromRow}
+          .getSortValue=${getSortValue}
+        ></lit-data-table>
+      </div>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'perturbations-table-module': PerturbationsTableModule;
+  }
+}

--- a/lit_nlp/client/package.json
+++ b/lit_nlp/client/package.json
@@ -23,6 +23,7 @@
     "scatter-gl": "^0.0.5",
     "seedrandom": "^3.0.5",
     "umap-js": "^1.3.2",
+    "uuid": "^8.3.0",
     "yarn": "^1.22.4"
   },
   "devDependencies": {

--- a/lit_nlp/client/services/deltas_service.ts
+++ b/lit_nlp/client/services/deltas_service.ts
@@ -1,0 +1,154 @@
+/**
+ * @license
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// tslint:disable:no-new-decorators
+import {action, computed, observable, reaction} from 'mobx';
+
+import {LitName, IndexedInput, ServiceUser} from '../lib/types';
+import {arrayContainsSame, findSpecKeys} from '../lib/utils';
+import {LitService} from './lit_service';
+import {AppState, SelectionService, RegressionService, ClassificationService} from './services';
+
+export type Source = {
+  modelName: string,
+  specKey: LitName,
+  fieldName: string
+};
+
+type ScoreReader = (id: string) => number | undefined;
+
+export type DeltaInfo = {
+  generationKeys: string[]
+  deltaRows: DeltaRow[]
+};
+
+export type DeltaRow = {
+  before?: number,
+  after?: number,
+  delta?: number,
+  d: IndexedInput,
+  parent: IndexedInput
+};
+
+
+/**
+ * A singleton service for computing deltas between example data points
+ * and perturbations.
+ */
+export class DeltasService extends LitService {
+  constructor(
+    private readonly appState: AppState,
+    private readonly selectionService: SelectionService,
+    private readonly classificationService: ClassificationService,
+    private readonly regressionService: RegressionService) {
+    super();
+  }
+
+  /* Get a list of sources for where to read values for deltas from (eg, which
+   * fields of the output spec match regression or multiclass prediction, after
+   * considering 0/1 multiclass predictions as a single source).
+   */
+  @computed
+  get sources(): Source[] {
+    return this.appState.currentModels.flatMap((modelName: string): Source[] => {
+      const modelSpec = this.appState.getModelSpec(modelName);
+      const outputSpecKeys: LitName[] = ['RegressionScore', 'MulticlassPreds'];
+      return outputSpecKeys.flatMap(specKey => {
+        const fieldNames = findSpecKeys(modelSpec.output, [specKey]);
+        return fieldNames.map(fieldName => ({modelName, specKey, fieldName}));
+       });
+    });
+  }
+
+  // Get a list of each time a generator was run, and the data points generated
+  public  deltaInfoFromSource(source: Source): DeltaInfo {
+    const byGeneration: {[generationKey: string]: IndexedInput[]} = {};
+    this.appState.generatedDataPoints.forEach((d: IndexedInput) => {
+      const key = d.meta.creationId;
+      byGeneration[key] = (byGeneration[key] || []).concat([d]);
+    });
+
+    const deltaRows = Object.keys(byGeneration).flatMap(generationKey => {
+      const ds = byGeneration[generationKey];
+      return this.deltaRowsForSource(source, ds)
+    });
+    return {
+      generationKeys: Object.keys(byGeneration),
+      deltaRows
+    };
+  }
+
+  private deltaRowsForSource(source: Source, ds: IndexedInput[]): DeltaRow[] {
+    const scoreReaders = this.getScoreReaders(source);
+    return scoreReaders.flatMap(scoreReader => {
+      return this.readDeltaRows(ds, source, scoreReader);
+    });
+  }
+
+  private readDeltaRows(ds: IndexedInput[], source: Source, readScore: ScoreReader): DeltaRow[] {
+    return ds.flatMap(d => {
+      const parent = this.appState.getCurrentInputDataById(d.meta.parentId);
+      if (parent == null) return [];
+      
+      const before = readScore(parent.id);
+      const after = readScore(d.id);
+      const delta = (before != null && after != null)
+        ? after - before
+        : undefined;
+      const deltaRow: DeltaRow = {before,after,delta,d,parent};
+      return [deltaRow];
+    });
+  }
+
+  private getScoreReaders(source: Source): ScoreReader[] {
+    const {modelName, specKey, fieldName} = source;
+
+    // Check for regression scores
+    if (specKey === 'RegressionScore') {
+      const readScoreForRegression: ScoreReader = id => {
+        return this.regressionService.regressionInfo[id]?.[modelName]?.[fieldName]?.prediction;
+      };
+      return [readScoreForRegression];
+    }
+
+    // Also support multiclass for multiple classes or binary
+    if (specKey === 'MulticlassPreds') {
+      const spec = this.appState.getModelSpec(modelName);
+      const predictionLabels = spec.output[fieldName].vocab!;
+      const margins = this.classificationService.marginSettings[modelName] || {};
+
+      const nullIdx = spec.output[fieldName].null_idx;
+      if (predictionLabels.length === 2 && nullIdx != null) {
+         const readScoreForMultiClassBinary: ScoreReader = id => {
+           return this.classificationService.classificationInfo[id]?.[modelName]?.[fieldName]?.predictions[1 - nullIdx];
+        };
+        return [readScoreForMultiClassBinary];
+      }
+
+      // Multiple classes for multiple tables.
+      predictionLabels.map((predictionLabel, index) => {
+        const readScoreForMultipleClasses: ScoreReader = id => {
+           return this.classificationService.classificationInfo[id]?.[modelName]?.[fieldName]?.predictions[index];
+        };
+        return readScoreForMultipleClasses;
+      });
+    }
+
+    // should never reach
+    return [];
+  }
+}

--- a/lit_nlp/client/services/selection_service.ts
+++ b/lit_nlp/client/services/selection_service.ts
@@ -25,9 +25,12 @@ import {SelectionObservedByUrlService} from './url_service';
 
 /**
  * The AppState interface for working with the SelectionService
+ * TODO(lit-dev): not sure why this is here, other than possibly limiting
+ * circular dependencies.
  */
 export interface AppState {
   currentInputData: IndexedInput[];
+  getIndexById: (id: string|null) => number;
   getCurrentInputDataById: (id: string) => IndexedInput | null;
   getExamplesById: (ids: string[]) => IndexedInput[];
 }
@@ -140,5 +143,12 @@ export class SelectionService extends LitService implements
   get selectedOrAllInputData(): IndexedInput[] {
     return this.selectedInputData.length > 0 ? this.selectedInputData :
                                                this.appState.currentInputData;
+  }
+
+  @computed
+  get selectedRowIndices(): number[] {
+    return this.selectedIds
+        .map((id) => this.appState.getIndexById(id))
+        .filter((index) => index !== -1);
   }
 }

--- a/lit_nlp/client/services/services.ts
+++ b/lit_nlp/client/services/services.ts
@@ -26,3 +26,4 @@ export {SliceService} from './slice_service';
 export {AppState} from './state_service';
 export {StatusService} from './status_service';
 export {UrlService} from './url_service';
+export {DeltasService} from './deltas_service';

--- a/lit_nlp/client/yarn.lock
+++ b/lit_nlp/client/yarn.lock
@@ -5082,6 +5082,11 @@ uuid@^3.3.2, uuid@^3.4.0:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
 
+uuid@^8.3.0:
+  version "8.3.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.0.tgz#ab738085ca22dc9a8c92725e459b1d507df5d6ea"
+  integrity sha512-fX6Z5o4m6XsXBdli9g7DtWgAx+osMsRRZFKma1mIUsLCz6vRvv+pz5VNbyu9UEDzpMWulZfvpgb/cmDXVulYFQ==
+
 v8-compile-cache@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.1.1.tgz#54bc3cdd43317bca91e35dcaf305b1a7237de745"


### PR DESCRIPTION
## What is it?
This adds a Perturbations Table Module, which shows how the predictions for datapoints created from generators compare to predictions for the original datapoints.  This allows comparing predictions for the original datapoints side by side with the perturbations,

## Why?
A minimal starting point for how LIT might support exploring how perturbations on an evaluation set impact predictions.

## Screenshot of UX
This module works for `RegressionScore` or `MultiClassPreds`.  After generating counterfactuals, the module shows which generated data points had the greatest change in prediction.  The example here is showing `quickstart_sst_demo.py`, which has `MultiClassPreds` with only [0,1] prediction labels for positive sentiment in movie comments.  This is after using `word_replacer` to create `great -> terrible` and `good -> amazing`.  By sorting by delta, we can see some points right away where the model's predictions changes quite a bit, in ways that perhaps reveal challenges with negation:

<img width="1329" alt="perturbations-table-module" src="https://user-images.githubusercontent.com/1056957/94740247-5132b500-0340-11eb-9461-2989c6f7345a.png">

#### UX notes:
1. The table lists sentences, sorted by the largest delta from before the generator -> after.  Sentences are highlighted using the same "by word" method from difflib.
2. If there are multiple scores available for the model, these are shown one above another.  Since the tables can be large, arrows above right of the table allow jumping to the next field (eg, for multiclass predictions):
<img width="1325" alt="Screen Shot 2020-09-30 at 5 23 50 PM" src="https://user-images.githubusercontent.com/1056957/94741208-cc489b00-0341-11eb-8b70-22c3ab7b9a20.png">
3. Selection and table sorting works as expected.
4. Arrows indicate direction of the delta, with opacity doubly encoding the magnitude of the change relative to all deltas in the set.

Critiques:
A. This doesn't help understand the whole distribution (ie, a visual representation would help as another module).

## Other engineering changes
#### DeltaService
Adds this to figure out what fields to read, and to compute deltas for them.  Can be used by another chart widget in a subsequent pull request.

#### StateService
Adds in dependency on `uuid`, and generates a uuid for tracking which call to the generator created the data point, and allow callers to store a text value for the rule.  This is done a bit as a workaround since the `meta` dictionary isn't part of the model's output spec, but alternately we could add this server side, but it seemed more complicated to try to fit this into `_get_datapoint_ids`.

#### lit-text-diff
This is factored out from `GeneratedTextModule`, so it can be reused in a slightly different context here.  This involves adding params to disable the labels, and to show only one sentence of the diff.   I moved the related test for `getTextDiff` over as well without any other changes, but didn't actually run them (adding `jasmine-ts` didn't just work, and I didn't look further).

#### lit-data-table
1. Allow `TemplateResult` in table cells (highlight changes the generator made, add delta arrow icons).
2. Abstract looking up data index for a row (column was hardcoded, previously marked TODO).
3. Support an initial sort column and direction (sort by delta in descending order).
4. Allow sort values to differ from display in cells (sort by sentence text, delta numeric value).

#### other bits
1. pull `formatLabelNumber` out from metrics UI into `util` (reuse it for formatting)
2. pull `selectedRowIndices` out from data table UI into `selectionService` (reuse it for tracking selection)

#### counterfactuals
1. add `meta.creationId` field (to group datapoints into the set created by a specific call to a generator)