### PR TITLE
Prediction score module: Include prediction label on y-axis

### DIFF
--- a/lit_nlp/client/modules/prediction_score_module.ts
+++ b/lit_nlp/client/modules/prediction_score_module.ts
@@ -800,7 +800,7 @@ export class PredictionScoreModule extends LitModule {
         <div class='plot-holder'>${svg`
           <svg class='scatterplot' data-key='${key}'
                                    data-label='${label}'
-                                   data-axisTitle='${axisTitle}'>
+                                   data-axis-title='${axisTitle}'>
           </svg>`}
         </div>
       `;


### PR DESCRIPTION
Fixes a bug in the render code writing out HTML data attribute for the y-axis label, which is later read by the update code but not found because of the case typo.

This example is looking at `glue.MNLIData("validation_matched")` with `glue_models.MNLIModel("huggingface/distilbert-base-uncased-finetuned-mnli")`:

### before
<img width="804" alt="Screen Shot 2020-10-14 at 11 17 11 AM" src="https://user-images.githubusercontent.com/1056957/96009858-24d26a80-0e0f-11eb-8e47-b0bca23bba72.png">

### after
<img width="802" alt="Screen Shot 2020-10-14 at 11 17 41 AM" src="https://user-images.githubusercontent.com/1056957/96009929-3b78c180-0e0f-11eb-8ce7-ed318c9262a8.png">
