### PR TITLE
Webpack fix after main.ts moved

### DIFF
--- a/lit_nlp/client/webpack/config.js
+++ b/lit_nlp/client/webpack/config.js
@@ -33,7 +33,7 @@ module.exports = (env = {}) => {
    * determine which output bundles to build and where to move them to
    */
   const entry = {
-    default: resolveDir('../default/main.ts'),
+    default: resolveDir('../main.ts'),
   };
   const fileManagerParams = {
     onEnd: {


### PR DESCRIPTION
WebPack builds broke in CI after https://github.com/PAIR-code/lit/commit/2994d7e00582cff528e3753b43ce81ced00a1b30 because `main.ts` moved from `./lit_nlp/default` to `./lit_nlp`. This updates the file path in the config to fix the issue.