### PR TITLE
Improve Saliency Docs

### DIFF
--- a/documentation/components.md
+++ b/documentation/components.md
@@ -304,6 +304,29 @@ To enable this method, your model should, as part of the
     be arrays of shape `<float>[num_tokens, emb_dim]` representing the gradient
     $\nabla_{x} \hat{y}$ of the embeddings with respect to the prediction
     $\hat{y}$.
+ 
+
+The model should have an optional input of type `TokenEmbeddings` with the same name as the output `TokenEmbeddings` field (see type system conventions), which will be used to compute the normalized dot product described above.
+
+An example spec would look like:
+
+```python
+def output_spec(self) -> lit_types.Spec:
+    return {
+        # ...
+        "tokens": lit_types.Tokens(),
+        "token_grads": lit_types.TokenGradients(align="tokens", grad_for="token_embs"),
+        "token_embs": lit_types.TokenEmbeddings(align="tokens")
+        # ...
+    }
+    
+def input_spec(self) -> lit_types.Spec:
+    return {
+        # ...
+        "token_embs": lit_types.TokenEmbeddings(align="tokens", required=False)
+        # ...
+    }
+```
 
 As with grad-norm, the model should return embeddings and gradients as NumPy
 arrays. The LIT `GradientDotInput` component will compute the dot products and

--- a/documentation/components.md
+++ b/documentation/components.md
@@ -259,8 +259,9 @@ soon. Available methods include:
 ### Gradient Norm
 
 This is a simple method, in which salience scores are proportional to the L2
-norm of the gradient, i.e. the score for token $$i$$ is $$ S(i) \propto
-||\nabla_{x_i} \hat{y}||_2 $$.
+norm of the gradient, i.e. the score for token $i$ is:
+
+$$S(i) \propto ||\nabla_{x_i} \hat{y}||_2$$
 
 To enable this method, your model should, as part of the
 [output spec and `predict()` implementation](./api.md#models):
@@ -270,12 +271,12 @@ To enable this method, your model should, as part of the
 *   Return a `TokenGradients` field with the `align` attribute pointing to the
     name of the `Tokens` field (i.e. `align="tokens"`). Values should be arrays
     of shape `<float>[num_tokens, emb_dim]` representing the gradient
-    $$\nabla_{x} \hat{y}$$ of the embeddings with respect to the prediction
-    $$\hat{y}$$.
+    $\nabla_{x} \hat{y}$ of the embeddings with respect to the prediction
+    $\hat{y}$.
 
 Because LIT is framework-agnostic, the model code is responsible for performing
 the gradient computation and returning the result as a NumPy array. The choice
-of $$\hat{y}$$ is up to the developer; typically for regression/scoring this is
+of $\hat{y}$ is up to the developer; typically for regression/scoring this is
 the raw score and for classification this is the score of the predicted (argmax)
 class.
 

--- a/documentation/components.md
+++ b/documentation/components.md
@@ -282,10 +282,13 @@ class.
 ### Gradient-dot-Input
 
 In this method, salience scores are proportional to the dot product of the input
-embeddings and their gradients, i.e. for token $$i$$ we take $$ S(i) \propto x_i
-\cdot \nabla_{x_i} \hat{y}$$. Compared to grad-norm, this gives directional
+embeddings and their gradients, i.e. for token $i$ we compute:
+
+$$S(i) \propto x_i \cdot \nabla_{x_i} \hat{y}$$
+
+Compared to grad-norm, this gives directional
 scores: a positive score is can be interpreted as that token having a positive
-influence on the prediction $$\hat{y}$$, while a negative score suggests that
+influence on the prediction $\hat{y}$, while a negative score suggests that
 the prediction would be stronger if that token was removed.
 
 To enable this method, your model should, as part of the
@@ -294,13 +297,13 @@ To enable this method, your model should, as part of the
 *   Return a `Tokens` field with values (as `List[str]`) containing the
     tokenized input.
 *   Return a `TokenEmbeddings` field with values as arrays of shape
-    `<float>[num_tokens, emb_dim]` containing the input embeddings $$x$$.
+    `<float>[num_tokens, emb_dim]` containing the input embeddings $x$.
 *   Return a `TokenGradients` field with the `align` attribute pointing to the
     name of the `Tokens` field (i.e. `align="tokens"`), and the `grad_for`
     attribute pointing to the name of the `TokenEmbeddings` field. Values should
     be arrays of shape `<float>[num_tokens, emb_dim]` representing the gradient
-    $$\nabla_{x} \hat{y}$$ of the embeddings with respect to the prediction
-    $$\hat{y}$$.
+    $\nabla_{x} \hat{y}$ of the embeddings with respect to the prediction
+    $\hat{y}$.
 
 As with grad-norm, the model should return embeddings and gradients as NumPy
 arrays. The LIT `GradientDotInput` component will compute the dot products and


### PR DESCRIPTION
Thanks for this awesome tool! Incredibly useful 😄 

This PR:

1. Cleans up some LaTex errors in the saliency documentation (2d112c64bc336a52349169f77ab27dbad8fe3c5b, 0fe073819e20ba3ef7c93bcc384895660119b646)
2. Clarifies that the token embeddings are needed for `GradientDotInput` (737d881a5760aad33a23198d78d521cf684b94e4)

---

I see that on the `dev` branch the requirement for token embeddings was removed in https://github.com/PAIR-code/lit/pull/608. However, I'm not sure what the release cadence is like for this project, so might be worth hotfixing the docs to avoid trip ups in the meanwhile.

If that's not desired, I'm happy to remove that commit and open this PR against the `dev` branch (where the LaTex errors still exist)

