### PR TITLE
Add .nojekyll so GH pages will serve _static and other files.

### DIFF
--- a/website/deploy.sh
+++ b/website/deploy.sh
@@ -3,3 +3,4 @@ rm -rf www && rm -rf ../docs && mkdir ../docs && \
 sphinx-build sphinx_src www/documentation && \
 eleventy --input=src --output=www --config=.eleventy.deploy.js && \
 cp -r www/. ../docs && rm -rf www
+touch ../docs/.nojekyll


### PR DESCRIPTION
Should fix website missing css and other assets, per https://github.blog/2009-12-29-bypassing-jekyll-on-github-pages/.