### PR TITLE
fix: add path traversal validation to datapoints endpoints

### DIFF
--- a/lit_nlp/app.py
+++ b/lit_nlp/app.py
@@ -215,6 +215,18 @@ class LitApp(object):
     )
     return [index[ex] if isinstance(ex, str) else ex for ex in inputs]
 
+  def _validate_data_path(self, path: str) -> str:
+    """Validate that a user-supplied path does not escape the data directory."""
+    resolved = os.path.realpath(path)
+    if self._data_dir:
+      base = os.path.realpath(self._data_dir)
+      if not resolved.startswith(base + os.sep) and resolved != base:
+        raise ValueError(
+            f'Path must be within data_dir ({self._data_dir})')
+    elif '..' in os.path.normpath(path).split(os.sep):
+      raise ValueError('Path traversal is not allowed')
+    return resolved
+
   def _save_datapoints(
       self,
       data,
@@ -231,6 +243,7 @@ class LitApp(object):
     if self._demo_mode:
       logging.warning('Attempted to save datapoints in demo mode.')
       return None
+    path = self._validate_data_path(path)
     return self._datasets[dataset_name].save(data['inputs'], path)
 
   def _load_datapoints(
@@ -249,6 +262,7 @@ class LitApp(object):
     if self._demo_mode:
       logging.warning('Attempted to load datapoints in demo mode.')
       return None
+    path = self._validate_data_path(path)
     dataset = self._datasets[dataset_name].load(path)
     return dataset.indexed_examples
 


### PR DESCRIPTION
## Summary

`_save_datapoints` and `_load_datapoints` in `app.py` pass user-supplied file paths directly to `open()` without validation. A path like `../../etc/passwd` reads or writes arbitrary files on the server.

## Fix

Add `_validate_data_path()` that resolves paths with `os.path.realpath()` and rejects anything outside the configured `data_dir`.

## Reproduction

```python
# With LIT server running:
requests.post('http://localhost:5432/save_datapoints', json={
    'dataset_name': 'sst_dev', 'path': '../../tmp/stolen',
    'inputs': [{'text': 'test'}]
})
```